### PR TITLE
appgwのバックエンドプールにVMを追加できるように変更

### DIFF
--- a/main.bicep
+++ b/main.bicep
@@ -1,0 +1,6 @@
+
+// create Vnet
+// create Application Gateway
+// create web vms
+// create internal load balancer
+// create postgreSQL with private endpoints

--- a/main.bicep
+++ b/main.bicep
@@ -1,6 +1,74 @@
+param location string = resourceGroup().location
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param bastionEnabled string 
+@minValue(1)
+@maxValue(3)
+param webVmCount int = 2
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param vmApacheEnabled string 
+
+param adminUsername string
+@secure()
+param adminPassword string
+
+var vnetName = 'vnet-webdb'
+var deployBastion = bastionEnabled == 'Enabled'
+var installApache = vmApacheEnabled == 'Enabled'
+
 
 // create Vnet
+module createVnet './modules/vnet.bicep' = {
+  name: 'createVnet'
+  params: {
+    location: location
+    vnetName: vnetName
+  }
+}
+
+// deploy Azure Bastion if needed
+module createAzureBastion './modules/bastion.bicep' = if(deployBastion) {
+  name: 'deployAzureBastion'
+  params: {
+    location: location
+    bastionVnetName: vnetName
+  }
+  dependsOn: [
+    createVnet
+  ]
+}
+
 // create Application Gateway
+module createAppGw './modules/appgw.bicep' = {
+  name: 'createAppGw'
+  params: {
+    location: location
+    appGwVnetName: vnetName
+  }
+  dependsOn: [
+    createVnet
+  ]
+}
+
 // create web vms
+module createWebVms './modules/vm.bicep' = [for i in range(1, webVmCount):{
+  name: 'createWebVm-${i}'
+  params: {
+    location: location
+    subnetId: createVnet.outputs.webSubnetId
+    vmName: 'webvm-${i}'
+    adminUsername: adminUsername
+    adminPassword: adminPassword
+    vmSize: 'Standard_B1s'
+    vmZone: '${i}'
+    installApache: installApache
+  }
+}]
+
 // create internal load balancer
 // create postgreSQL with private endpoints

--- a/main.bicep
+++ b/main.bicep
@@ -43,18 +43,6 @@ module createAzureBastion './modules/bastion.bicep' = if(deployBastion) {
   ]
 }
 
-// create Application Gateway
-module createAppGw './modules/appgw.bicep' = {
-  name: 'createAppGw'
-  params: {
-    location: location
-    appGwVnetName: vnetName
-  }
-  dependsOn: [
-    createVnet
-  ]
-}
-
 // create web vms
 module createWebVms './modules/vm.bicep' = [for i in range(1, webVmCount):{
   name: 'createWebVm-${i}'
@@ -69,6 +57,19 @@ module createWebVms './modules/vm.bicep' = [for i in range(1, webVmCount):{
     installApache: installApache
   }
 }]
+
+// create Application Gateway
+module createAppGw './modules/appgw.bicep' = {
+  name: 'createAppGw'
+  params: {
+    location: location
+    appGwVnetName: vnetName
+    backendVmPrivateIps: [for i in range(0, webVmCount): createWebVms[i].outputs.vmPrivateIp]
+  }
+  dependsOn: [
+    createVnet
+  ]
+}
 
 // create internal load balancer
 // create postgreSQL with private endpoints

--- a/main.bicepparam
+++ b/main.bicepparam
@@ -1,0 +1,7 @@
+using './main.bicep'
+
+param bastionEnabled = 'Disabled'
+param vmApacheEnabled = 'Enabled'
+param adminUsername = 'AzureAdmin'
+param adminPassword = 'Passw0rd1234!'
+

--- a/modules/appgw.bicep
+++ b/modules/appgw.bicep
@@ -1,0 +1,122 @@
+param location string
+param appGwVnetName string
+
+var appGwAddressPrefix = '10.0.0.0/24'
+var appGwSubnetName = 'appgw-subnet'
+var appGwName = 'appgw-front'
+
+resource hubVnet 'Microsoft.Network/virtualNetworks@2023-04-01' existing = {
+  name: appGwVnetName
+}
+
+resource appgwSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01' = {
+  name: appGwSubnetName
+  parent: hubVnet
+  properties: {
+    addressPrefix: appGwAddressPrefix
+  }
+}
+
+resource appgwPip 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
+  name: '${appGwName}-pip'
+  location: location
+  sku:{
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}
+
+resource applicationGateway 'Microsoft.Network/applicationGateways@2023-04-01' = {
+  name: appGwName
+  location: location
+  properties: {
+    sku: {
+      name: 'Standard_v2'
+      tier: 'Standard_v2'
+    }
+    gatewayIPConfigurations: [
+      {
+        name: 'appGwIpConfig'
+        properties: {
+          subnet: {
+            id: appgwSubnet.id
+          }
+        }
+      }
+    ]
+    frontendIPConfigurations: [
+      {
+        name: 'appGwPublicFrontendIp'
+        properties: {
+          publicIPAddress: {
+            id: appgwPip.id
+          }
+        }
+      }
+    ]
+    frontendPorts: [
+      {
+        name: 'port_80'
+        properties: {
+          port: 80
+        }
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: 'http-backend'
+      }
+    ]
+    backendHttpSettingsCollection: [
+      {
+        name: 'http-setting'
+        properties: {
+          port: 80
+          protocol: 'Http'
+          cookieBasedAffinity: 'Disabled'
+        }
+      }
+    ]
+    httpListeners: [
+      {
+        name: 'http-listener'
+        properties: {
+          frontendIPConfiguration: {
+            id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGwName, 'appGwPublicFrontendIp')
+          }
+          frontendPort: {
+            id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGwName, 'port_80')
+          }
+          protocol: 'Http'
+          sslCertificate: null
+        }
+      }
+    ]
+    requestRoutingRules: [
+      {
+        name: 'routing-rule'
+        properties: {
+          priority: 100
+          ruleType: 'Basic'
+          httpListener: {
+            id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGwName, 'http-listener')
+          }
+          backendAddressPool: {
+            id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGwName, 'http-backend')
+          }
+          backendHttpSettings: {
+            id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGwName, 'http-setting')
+          }
+        }
+      }
+    ]
+    enableHttp2: false
+    autoscaleConfiguration: {
+      minCapacity: 0
+      maxCapacity: 10
+    }
+  }
+}

--- a/modules/appgw.bicep
+++ b/modules/appgw.bicep
@@ -1,5 +1,6 @@
 param location string
 param appGwVnetName string
+param backendVmPrivateIps array
 
 var appGwAddressPrefix = '10.0.0.0/24'
 var appGwSubnetName = 'appgw-subnet'
@@ -68,6 +69,14 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2023-04-01' =
     backendAddressPools: [
       {
         name: 'http-backend'
+        // ここにバックエンドのVMのプライベートIPを指定する
+        properties: {
+          backendAddresses: [
+            for ip in backendVmPrivateIps: {
+                ipAddress: ip
+            }
+          ]
+        }
       }
     ]
     backendHttpSettingsCollection: [

--- a/modules/bastion.bicep
+++ b/modules/bastion.bicep
@@ -1,0 +1,49 @@
+param location string
+param bastionVnetName string
+
+@description('Address prefix for AzureBastionSubnet')
+var bastionAddressPrefix = '10.0.100.0/24'
+
+resource hubVnet 'Microsoft.Network/virtualNetworks@2023-04-01' existing = {
+  name: bastionVnetName
+}
+
+resource bastionSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-04-01' = {
+  name: 'AzureBastionSubnet'
+  parent: hubVnet
+  properties: {
+    addressPrefix: bastionAddressPrefix
+  }
+}
+
+resource bastionPip 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
+  name: 'bastion-hub-pip'
+  location: location
+  sku:{
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}
+
+resource azureBastion 'Microsoft.Network/bastionHosts@2023-04-01' = {
+  name: 'bastion-hub'
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'bastionIpConfig'
+        properties: {
+          subnet: {
+            id: bastionSubnet.id
+          }
+          publicIPAddress: {
+            id: bastionPip.id
+          }
+        }
+      }
+    ]
+  }
+}

--- a/modules/vm.bicep
+++ b/modules/vm.bicep
@@ -1,13 +1,19 @@
 param location string
 param subnetId string
-param nicName string
 param vmName string
 param adminUsername string
 @secure()
 param adminPassword string
-param diskName string
+// param diskName string
 param vmSize string
 param vmZone string
+param installApache bool
+
+var nicName = '${vmName}-nic'
+var osDiskName = '${vmName}-disk'
+// var vmDeployZone = {
+//   value: vmZone
+// }
 
 // create network interface for ubuntu vm
 resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
@@ -49,7 +55,7 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2023-03-01' = {
         version: 'latest'
       }
       osDisk: {
-        name: diskName
+        name: osDiskName
         caching: 'ReadWrite'
         createOption: 'FromImage'
       }
@@ -66,11 +72,28 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2023-03-01' = {
         enabled: false
       }
     }
-    zones: [
-      vmZone
-    ]
+  }
+  zones: [
+    vmZone
+  ]
+}
+
+// install apache on ubuntu vm if needed
+resource vmInstallApache 'Microsoft.Compute/virtualMachines/extensions@2023-03-01' = if (installApache) {
+  name: 'installApache-${vmName}'
+  location: location
+  parent: ubuntuVM
+  properties: {
+    publisher: 'Microsoft.Azure.Extensions' // Linux VM のカスタム スクリプト拡張機能のパブリッシャー名
+    type: 'CustomScript' // Linux VM のカスタム スクリプト拡張機能のタイプ名
+    typeHandlerVersion: '2.0' // Linux VM のカスタム スクリプト拡張機能のバージョン
+    autoUpgradeMinorVersion: true
+    settings: {
+      // カスタム スクリプト拡張機能に渡すコマンド
+      commandToExecute: 'sudo apt-get -y update && sudo apt-get -y install apache2 && sudo systemctl start apache2.service'
+    }
   }
 }
 
-@description('return the private ip address of the vm to use from parent template')
-output vmPrivateIp string = networkInterface.properties.ipConfigurations[0].properties.privateIPAddress
+// @description('return the private ip address of the vm to use from parent template')
+// output vmPrivateIp string = networkInterface.properties.ipConfigurations[0].properties.privateIPAddress

--- a/modules/vm.bicep
+++ b/modules/vm.bicep
@@ -1,0 +1,76 @@
+param location string
+param subnetId string
+param nicName string
+param vmName string
+param adminUsername string
+@secure()
+param adminPassword string
+param diskName string
+param vmSize string
+param vmZone string
+
+// create network interface for ubuntu vm
+resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
+  name: nicName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: subnetId
+          }
+        }
+      }
+    ]
+  }
+}
+
+// create ubuntu vm in spoke vnet
+resource ubuntuVM 'Microsoft.Compute/virtualMachines@2023-03-01' = {
+  name: vmName
+  location: location
+  properties: {
+    hardwareProfile: {
+      vmSize: vmSize
+    }
+    osProfile: {
+      computerName: vmName
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'Canonical'
+        offer: '0001-com-ubuntu-server-focal'
+        sku: '20_04-lts-gen2'
+        version: 'latest'
+      }
+      osDisk: {
+        name: diskName
+        caching: 'ReadWrite'
+        createOption: 'FromImage'
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: networkInterface.id
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: false
+      }
+    }
+    zones: [
+      vmZone
+    ]
+  }
+}
+
+@description('return the private ip address of the vm to use from parent template')
+output vmPrivateIp string = networkInterface.properties.ipConfigurations[0].properties.privateIPAddress

--- a/modules/vm.bicep
+++ b/modules/vm.bicep
@@ -95,5 +95,5 @@ resource vmInstallApache 'Microsoft.Compute/virtualMachines/extensions@2023-03-0
   }
 }
 
-// @description('return the private ip address of the vm to use from parent template')
-// output vmPrivateIp string = networkInterface.properties.ipConfigurations[0].properties.privateIPAddress
+@description('return the private ip address of the vm to use from parent template')
+output vmPrivateIp string = networkInterface.properties.ipConfigurations[0].properties.privateIPAddress

--- a/modules/vnet.bicep
+++ b/modules/vnet.bicep
@@ -1,8 +1,8 @@
 param location string
-param installApache bool
-param deployAzureBastion bool
+// param installApache bool
+// param deployAzureBastion bool
+param vnetName string
 
-var appgwSubnetName = 'subnet-appgw'
 var webSubnetName = 'subnet-web'
 var dbSubnetName = 'subnet-db'
 
@@ -10,26 +10,26 @@ resource nsgWebSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
   name: 'nsg-web'
   location: location
   properties: {
-    // securityRules: [
-    //   {
-    //     name: 'nsgRule'
-    //     properties: {
-    //       description: 'description'
-    //       protocol: 'Tcp'
-    //       sourcePortRange: '*'
-    //       destinationPortRange: '*'
-    //       sourceAddressPrefix: '*'
-    //       destinationAddressPrefix: '*'
-    //       access: 'Allow'
-    //       priority: 100
-    //       direction: 'Inbound'
-    //     }
-    //   }
-    // ]
+    securityRules: [
+      {
+        name: 'nsgRule'
+        properties: {
+          description: 'allow http traffic from any'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '80'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 1000
+          direction: 'Inbound'
+        }
+      }
+    ]
   }
 }
 
-resource nsgDBSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+resource nsgDbSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
   name: 'nsg-db'
   location: location
   properties: {
@@ -53,8 +53,8 @@ resource nsgDBSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
 }
 
 // create vnet
-resource webdbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
-  name: 'vnet-webdb'
+resource webDbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: vnetName
   location: location
   properties: {
     addressSpace: {
@@ -63,12 +63,12 @@ resource webdbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
       ]
     }
     subnets: [
-      {
-        name: appgwSubnetName
-        properties: {
-          addressPrefix: '10.0.0.0/24'
-        }
-      }
+      // {
+      //   name: appgwSubnetName
+      //   properties: {
+      //     addressPrefix: '10.0.0.0/24'
+      //   }
+      // }
       {
         name: webSubnetName
         properties: {
@@ -83,7 +83,7 @@ resource webdbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
         properties: {
           addressPrefix: '10.0.2.0/24'
           networkSecurityGroup: {
-            id: nsgDBSubnet.id
+            id: nsgDbSubnet.id
           }
         }
       }
@@ -105,4 +105,4 @@ resource webdbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
 //   ]
 // }
 
-output webSubnetId string = webdbVnet::webSubnet.id
+output webSubnetId string = webDbVnet::webSubnet.id

--- a/modules/vnet.bicep
+++ b/modules/vnet.bicep
@@ -1,0 +1,108 @@
+param location string
+param installApache bool
+param deployAzureBastion bool
+
+var appgwSubnetName = 'subnet-appgw'
+var webSubnetName = 'subnet-web'
+var dbSubnetName = 'subnet-db'
+
+resource nsgWebSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+  name: 'nsg-web'
+  location: location
+  properties: {
+    // securityRules: [
+    //   {
+    //     name: 'nsgRule'
+    //     properties: {
+    //       description: 'description'
+    //       protocol: 'Tcp'
+    //       sourcePortRange: '*'
+    //       destinationPortRange: '*'
+    //       sourceAddressPrefix: '*'
+    //       destinationAddressPrefix: '*'
+    //       access: 'Allow'
+    //       priority: 100
+    //       direction: 'Inbound'
+    //     }
+    //   }
+    // ]
+  }
+}
+
+resource nsgDBSubnet 'Microsoft.Network/networkSecurityGroups@2023-04-01' = {
+  name: 'nsg-db'
+  location: location
+  properties: {
+    // securityRules: [
+    //   {
+    //     name: 'nsgRule'
+    //     properties: {
+    //       description: 'description'
+    //       protocol: 'Tcp'
+    //       sourcePortRange: '*'
+    //       destinationPortRange: '*'
+    //       sourceAddressPrefix: '*'
+    //       destinationAddressPrefix: '*'
+    //       access: 'Allow'
+    //       priority: 100
+    //       direction: 'Inbound'
+    //     }
+    //   }
+    // ]
+  }
+}
+
+// create vnet
+resource webdbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: 'vnet-webdb'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: appgwSubnetName
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+      {
+        name: webSubnetName
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: nsgWebSubnet.id
+          }
+        }
+      }
+      {
+        name: dbSubnetName
+        properties: {
+          addressPrefix: '10.0.2.0/24'
+          networkSecurityGroup: {
+            id: nsgDBSubnet.id
+          }
+        }
+      }
+    ]
+  }
+  resource webSubnet 'subnets' existing = {
+    name: webSubnetName
+  }
+}
+
+// // create azure bastion after hub vnet creattion if deployAzureBastion is true
+// module createAzureBastion './bastion.bicep' = if(deployAzureBastion) {
+//   name: 'createAzureBastion'
+//   params: {
+//     location: location
+//   }
+//   dependsOn: [
+//     hubVnet
+//   ]
+// }
+
+output webSubnetId string = webdbVnet::webSubnet.id


### PR DESCRIPTION
vm.bicepの各ループからのoutputを取り出す方法は以下

```
// create Application Gateway
module createAppGw './modules/appgw.bicep' = {
  name: 'createAppGw'
  params: {
    location: location
    appGwVnetName: vnetName
    backendVmPrivateIps: [for i in range(0, webVmCount): createWebVms[i].outputs.vmPrivateIp]
  }
  dependsOn: [
    createVnet
  ]
}
```

appgwの作成時のプロパティとしてarrayをループさせてIPを複数渡す
```
    backendAddressPools: [
      {
        name: 'http-backend'
        properties: {
          backendAddresses: [
            for ip in backendVmPrivateIps: {
                ipAddress: ip
            }
          ]
        }
      }
    ]
```