### PR TITLE
postgresql deployment + alpha

### DIFF
--- a/main.bicepparam
+++ b/main.bicepparam
@@ -1,7 +1,6 @@
 using './main.bicep'
 
 param bastionEnabled = 'Disabled'
-param vmApacheEnabled = 'Enabled'
 param adminUsername = 'AzureAdmin'
 param adminPassword = 'Passw0rd1234!'
 

--- a/modules/appgw.bicep
+++ b/modules/appgw.bicep
@@ -3,8 +3,8 @@ param appGwVnetName string
 param backendVmPrivateIps array
 
 var appGwAddressPrefix = '10.0.0.0/24'
-var appGwSubnetName = 'appgw-subnet'
-var appGwName = 'appgw-front'
+var appGwSubnetName = 'subnet-appgw'
+var appGwName = 'appgw-public'
 
 resource hubVnet 'Microsoft.Network/virtualNetworks@2023-04-01' existing = {
   name: appGwVnetName

--- a/modules/cloud-init.yml
+++ b/modules/cloud-init.yml
@@ -1,0 +1,10 @@
+#cloud-config
+timezone: Asia/Tokyo
+package_upgrade: true
+package_update: true
+packages:
+  - git
+  - vim
+  - apache2
+run_cmd:
+  - sudo systemctl start apache2.service

--- a/modules/postgreSql.bicep
+++ b/modules/postgreSql.bicep
@@ -1,0 +1,61 @@
+param location string
+param availabilityZone string
+param postgreSqlAdminUser string
+
+@secure()
+param postgreSqlAdminPassword string
+param serverName string
+param linkedVnetId string
+param dbSubnetId string
+
+var serverEdition = 'GeneralPurpose'
+var skuSizeGB = 128
+var dbInstanceType = 'Standard_D2ds_v4'
+var haMode = 'ZoneRedundant'
+var version = '12'
+
+resource postgreSqlPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: '${serverName}.private.postgres.database.azure.com'
+  location: 'global'
+}
+
+resource virtualNetworkLinks 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  name: 'vnet-link-${serverName}'
+  location: 'global'
+  parent: postgreSqlPrivateDnsZone
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: linkedVnetId
+    }
+  }
+}
+
+resource postgreSql 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+  name: serverName
+  location: location
+  sku: {
+    name: dbInstanceType
+    tier: serverEdition
+  }
+  properties: {
+    version: version
+    administratorLogin: postgreSqlAdminUser
+    administratorLoginPassword: postgreSqlAdminPassword
+    network: {
+      delegatedSubnetResourceId: dbSubnetId
+      privateDnsZoneArmResourceId: postgreSqlPrivateDnsZone.id
+    }
+    highAvailability: {
+      mode: haMode
+    }
+    storage: {
+      storageSizeGB: skuSizeGB
+    }
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Disabled'
+    }
+    availabilityZone: availabilityZone
+  }
+}

--- a/modules/vm.bicep
+++ b/modules/vm.bicep
@@ -4,16 +4,11 @@ param vmName string
 param adminUsername string
 @secure()
 param adminPassword string
-// param diskName string
 param vmSize string
 param vmZone string
-param installApache bool
 
 var nicName = '${vmName}-nic'
 var osDiskName = '${vmName}-disk'
-// var vmDeployZone = {
-//   value: vmZone
-// }
 
 // create network interface for ubuntu vm
 resource networkInterface 'Microsoft.Network/networkInterfaces@2023-04-01' = {
@@ -46,6 +41,7 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2023-03-01' = {
       computerName: vmName
       adminUsername: adminUsername
       adminPassword: adminPassword
+      customData: loadFileAsBase64('./cloud-init.yml') 
     }
     storageProfile: {
       imageReference: {
@@ -76,23 +72,6 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2023-03-01' = {
   zones: [
     vmZone
   ]
-}
-
-// install apache on ubuntu vm if needed
-resource vmInstallApache 'Microsoft.Compute/virtualMachines/extensions@2023-03-01' = if (installApache) {
-  name: 'installApache-${vmName}'
-  location: location
-  parent: ubuntuVM
-  properties: {
-    publisher: 'Microsoft.Azure.Extensions' // Linux VM のカスタム スクリプト拡張機能のパブリッシャー名
-    type: 'CustomScript' // Linux VM のカスタム スクリプト拡張機能のタイプ名
-    typeHandlerVersion: '2.0' // Linux VM のカスタム スクリプト拡張機能のバージョン
-    autoUpgradeMinorVersion: true
-    settings: {
-      // カスタム スクリプト拡張機能に渡すコマンド
-      commandToExecute: 'sudo apt-get -y update && sudo apt-get -y install apache2 && sudo systemctl start apache2.service'
-    }
-  }
 }
 
 @description('return the private ip address of the vm to use from parent template')

--- a/modules/vnet.bicep
+++ b/modules/vnet.bicep
@@ -82,6 +82,14 @@ resource webDbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
         name: dbSubnetName
         properties: {
           addressPrefix: '10.0.2.0/24'
+          delegations: [
+            {
+              name: 'Microsoft.DBforPostgreSQL/flexibleServers'
+              properties: {
+                serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
+              }
+            }
+          ]
           networkSecurityGroup: {
             id: nsgDbSubnet.id
           }
@@ -91,6 +99,9 @@ resource webDbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   }
   resource webSubnet 'subnets' existing = {
     name: webSubnetName
+  }
+  resource dbSubnet 'subnets' existing = {
+    name: dbSubnetName
   }
 }
 
@@ -105,4 +116,6 @@ resource webDbVnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
 //   ]
 // }
 
+output webDbVnetId string = webDbVnet.id
 output webSubnetId string = webDbVnet::webSubnet.id
+output dbSubnetId string = webDbVnet::dbSubnet.id


### PR DESCRIPTION
PostgreSQLのVNET統合デプロイを追加。Private Endpointを利用するリソースではなかったため、そこの教育を含みたい場合にはPrivate Endpointを利用する別のリソースが必要。序にVMへのApacheのインストールにcloud-initを利用するように変更、Webサーバ用のカスタムイメージからデプロイするのが通常のやり方だと思うがそこまでの用意が面倒。Marketplaceにあるイメージはサブスクリプションの都合上利用できなかった。